### PR TITLE
Update CI.yml: use `lts` rather than `1.9`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - 'lts'
           - '1'
         os:
           - ubuntu-latest


### PR DESCRIPTION
It seems that ITernsorMPS.jl has stopped supporting Julia 1.9.

https://github.com/ITensor/ITensorMPS.jl/blob/8896bb17f8a797f8e058df257168317df0c3cc16/Project.toml#L51 
